### PR TITLE
Add failFast option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ When `aggregate` option is set to `true`, aggregated data will also be included:
 ```json
 {
   "runs": 3,
+  "failFast": false,
   "aggregate": true,
   "lighthouse": {
     "flags": {},
@@ -130,6 +131,12 @@ When `aggregate` option is set to `true`, aggregated data will also be included:
 `Required`
 
 Specifies how many times Lighthouse will run. A higher value contibutes more robust results but takes a long time to finish measuring.
+
+#### failFast
+
+`Optional` (Default: `true`)
+
+If set true, Lightkeeper will terminate its process immediately after an error occurs. Otherwise, it will continue to try running Lighthouse for given times.
 
 #### aggregate
 

--- a/README.md
+++ b/README.md
@@ -127,21 +127,31 @@ When `aggregate` option is set to `true`, aggregated data will also be included:
 
 #### runs
 
+`Required`
+
 Specifies how many times Lighthouse will run. A higher value contibutes more robust results but takes a long time to finish measuring.
 
 #### aggregate
+
+`Optional` (Default: `false`)
 
 If set true, Lightkeeper will also report an aggregated result of multiple runs in addition to metrics collected by each run.
 
 #### lighthouse.flags
 
+`Optional` (Default: `{}`)
+
 This object is passed to the second argument of `lighthouse()`. The available flags can be found in [Lighthouse's document](https://github.com/GoogleChrome/lighthouse/blob/master/docs/readme.md#differences-from-cli-flags).
 
 #### lighthouse.config
 
+`Optional` (Default: `{}`)
+
 This object is passed to the third argument of `lighthouse()`. See [Lighthouse's document](https://github.com/GoogleChrome/lighthouse/blob/master/docs/readme.md#configuration) for the full list of available options.
 
 #### metrics
+
+`Required`
 
 A list of metrics that will be extracted from a Lighthouse output.
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,6 @@
 {
   "runs": 3,
+  "failFast": false,
   "aggregate": true,
   "lighthouse": {
     "flags": {},

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ async function main(): Promise<void> {
     url: argv.url,
     device: argv.device,
     runs: config.runs,
+    failFast: config.failFast,
     aggregate: config.aggregate,
     metricConfigs: config.metrics,
     lighthouseFlags: config.lighthouse?.flags,

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,7 @@ import { MetricConfig } from './metrics';
 
 export type LightkeeperConfig = {
   runs: number;
-  aggregate: boolean;
+  aggregate?: boolean;
   lighthouse?: {
     flags: unknown;
     config: unknown;

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import { MetricConfig } from './metrics';
 
 export type LightkeeperConfig = {
   runs: number;
+  failFast?: boolean;
   aggregate?: boolean;
   lighthouse?: {
     flags: unknown;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,10 @@ export async function lightkeeper({
   url: string;
   device: Device;
   runs: number;
-  aggregate: boolean;
+  aggregate?: boolean;
   metricConfigs: MetricConfig[];
-  lighthouseFlags: LighthouseFlagsSettings;
-  lighthouseConfig: LighthouseConfig;
+  lighthouseFlags?: LighthouseFlagsSettings;
+  lighthouseConfig?: LighthouseConfig;
 }): Promise<LightkeeperResults> {
   const chrome = await chromeLauncher.launch({
     chromeFlags: ['--headless', '--no-sandbox'],
@@ -62,7 +62,7 @@ export async function lightkeeper({
       results.push({ metrics });
     }
 
-    if (aggregate) {
+    if (aggregate === true) {
       const aggregatedResults = aggregateResults({ results });
       return { results, aggregated: aggregatedResults };
     }


### PR DESCRIPTION
If it's set `false`, Lightkeeper will continue to try running Lighthouse for given times. Useful if you don't want Lightkeeper to stop measuring even after one of runs throws.